### PR TITLE
fix: relax python version requirement

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,7 +3,7 @@ name = "apis"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 dependencies = [
     "fastapi>=0.115.8",
     "uvicorn>=0.34.0",


### PR DESCRIPTION
## Summary
- update required Python version to 3.10 in `backend/pyproject.toml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c52ab04f08326a31f2009f94ce135