### PR TITLE
Fix venv path in backend scripts

### DIFF
--- a/backend/install.bat
+++ b/backend/install.bat
@@ -1,10 +1,10 @@
 @echo off
 echo Removing existing virtual environment...
-if exist venv rmdir /s /q venv
+if exist .venv rmdir /s /q .venv
 
 echo Creating virtual environment...
-python -m venv venv
-call venv\Scripts\activate
+python -m venv .venv
+call .venv\Scripts\activate
 
 echo Updating pip and installing basic tools...
 python -m pip install --upgrade pip wheel setuptools

--- a/backend/install.sh
+++ b/backend/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-uv venv
-source ./venv/bin/activate
+uv venv .venv
+source .venv/bin/activate
 uv pip install -r requirements.txt

--- a/backend/run.bat
+++ b/backend/run.bat
@@ -1,3 +1,3 @@
 @echo off
-call venv\Scripts\activate
+call .venv\Scripts\activate
 uvicorn main:app --reload


### PR DESCRIPTION
## Summary
- use `.venv` consistently in backend install scripts
- adjust Windows run script to match

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cb0c6ab0883268c6b5bb08fea376e