### PR TITLE
Add asyncpg dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ fastapi==0.104.1
 uvicorn[standard]==0.24.0
 python-multipart==0.0.6
 psycopg2-binary==2.9.9  # Driver PostgreSQL pré-compilado
+asyncpg==0.29.0
 aiohttp==3.9.3  # Para requisições assíncronas
 pydantic==2.3.0  # Versão mais estável sem necessidade de Rust
 email-validator==2.0.0  # Para suporte a email


### PR DESCRIPTION
## Summary
- include asyncpg dependency in backend requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb0c5320c8326b64063d17a80ad99