### PR TITLE
Fix Vite resolve alias

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -80,13 +80,7 @@ export default defineConfig({
 			},
 		},
 	},
-	resolve: {
-		alias: {
-			resolve: {
-				alias: {
-					"@": path.resolve(__dirname, "./src"),
-				},
-			},
-		},
-	},
+        resolve: {
+                alias: { "@": path.resolve(__dirname, "./src") }
+        },
 });


### PR DESCRIPTION
## Summary
- fix alias config in frontend/vite.config.ts to avoid nested resolve entries

## Testing
- `yarn lint` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685cb769553c83268c153649d8d0a371