### PR TITLE
Fix mismatched backend versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ make run-backend
 make run-frontend
 ```
 
+### Dependency versions
+
+The backend uses `backend/requirements.txt` as the authoritative list of
+package versions. `backend/pyproject.toml` mirrors those pins for convenience
+but the `requirements.txt` file is used when installing.
+
 ## Gotchas
 
 The backend server runs on port 8000 and the frontend development server runs on port 5173. The frontend Vite server proxies API requests to the backend on port 8000.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "fastapi>=0.115.8",
-    "uvicorn>=0.34.0",
+    # Versions are kept in sync with requirements.txt
+    "fastapi==0.104.1",
+    "uvicorn[standard]==0.24.0",
 ]


### PR DESCRIPTION
## Summary
- sync FastAPI and Uvicorn versions in the backend `pyproject.toml`
- document which file defines backend dependency versions

## Testing
- `python -m compileall -q backend/app backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685cb76ac8c8832697904a39a4350cff