### PR TITLE
Fix yarn version in install script

### DIFF
--- a/frontend/install.sh
+++ b/frontend/install.sh
@@ -2,7 +2,7 @@
 
 corepack enable
 
-yarn set version stable
+yarn set version 4.0.2
 
 yarn install 
 


### PR DESCRIPTION
## Summary
- match README instructions in `frontend/install.sh`

## Testing
- `make` *(fails: Failed to fetch packages due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_685cc06f08108326b2bcedf0e5802c64