### PR TITLE
Hash passwords before saving

### DIFF
--- a/backend/app/apis/users/__init__.py
+++ b/backend/app/apis/users/__init__.py
@@ -1,14 +1,27 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, EmailStr
 import asyncpg
+from passlib.context import CryptContext
 from app.libs.database import get_db_connection
 
 router = APIRouter()
 
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    """Hash a plaintext password."""
+    return pwd_context.hash(password)
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    """Verify a plaintext password against a hash."""
+    return pwd_context.verify(password, hashed)
+
 class RegistrationRequest(BaseModel):
     email: EmailStr
-    password: str # In a real app, this would be hashed
-    role: str # 'installer' or 'supplier'
+    password: str
+    role: str  # 'installer' or 'supplier'
     full_name: str
     company_name: str | None = None
 
@@ -21,7 +34,7 @@ class UserResponse(BaseModel):
 
 @router.post("/register", response_model=UserResponse)
 async def register_user(body: RegistrationRequest, db: asyncpg.Connection = Depends(get_db_connection)):
-    # In a real app, you would hash the password here
+    password_hash = hash_password(body.password)
     
     # Check if user already exists
     user_exists = await db.fetchval("SELECT id FROM users WHERE email = $1", body.email)
@@ -46,11 +59,11 @@ async def register_user(body: RegistrationRequest, db: asyncpg.Connection = Depe
     # Create user
     new_user_id = await db.fetchval(
         """
-        INSERT INTO users (id, email, full_name, role_id, company_id)
-        VALUES (gen_random_uuid(), $1, $2, $3, $4)
+        INSERT INTO users (id, email, full_name, role_id, company_id, password_hash)
+        VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)
         RETURNING id
         """,
-        body.email, body.full_name, role_id, company_id
+        body.email, body.full_name, role_id, company_id, password_hash
     )
 
     return UserResponse(
@@ -59,4 +72,29 @@ async def register_user(body: RegistrationRequest, db: asyncpg.Connection = Depe
         role=body.role,
         full_name=body.full_name,
         company_name=body.company_name
+    )
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+@router.post("/login", response_model=UserResponse)
+async def login_user(body: LoginRequest, db: asyncpg.Connection = Depends(get_db_connection)):
+    user_record = await db.fetchrow(
+        "SELECT id, email, full_name, role_id, company_id, password_hash FROM users WHERE email = $1",
+        body.email,
+    )
+    if not user_record or not verify_password(body.password, user_record["password_hash"]):
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+
+    role_name = await db.fetchval("SELECT role_name FROM user_roles WHERE id = $1", user_record["role_id"])
+
+    return UserResponse(
+        id=str(user_record["id"]),
+        email=user_record["email"],
+        role=role_name,
+        full_name=user_record["full_name"],
+        company_name=user_record["company_id"],
     )

--- a/backend/migrations/003_add_password_hash.sql
+++ b/backend/migrations/003_add_password_hash.sql
@@ -1,0 +1,3 @@
+-- Migration to add password_hash column to users table
+ALTER TABLE IF EXISTS users
+    ADD COLUMN IF NOT EXISTS password_hash TEXT;


### PR DESCRIPTION
## Summary
- secure passwords using bcrypt
- add login API to validate hashed passwords
- add migration for password storage

## Testing
- `bash backend/install.sh` *(fails: could not access pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_685cc0705d5c8326b84859328f8608e1