### PR TITLE
Use connection pool for database

### DIFF
--- a/backend/app/libs/database.py
+++ b/backend/app/libs/database.py
@@ -2,12 +2,32 @@ import os
 import asyncpg
 from typing import AsyncGenerator
 
+pool: asyncpg.Pool | None = None
+
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@localhost/solarsync")
 
+
+async def init_db_pool() -> None:
+    """Initialize the asyncpg connection pool."""
+    global pool
+    if pool is None:
+        pool = await asyncpg.create_pool(DATABASE_URL)
+
+
+async def close_db_pool() -> None:
+    """Close the asyncpg connection pool."""
+    global pool
+    if pool is not None:
+        await pool.close()
+        pool = None
+
 async def get_db_connection() -> AsyncGenerator[asyncpg.Connection, None]:
-    """Get database connection for dependency injection."""
-    conn = await asyncpg.connect(DATABASE_URL)
+    """Acquire a connection from the pool for dependency injection."""
+    if pool is None:
+        await init_db_pool()
+    assert pool is not None
+    conn = await pool.acquire()
     try:
         yield conn
     finally:
-        await conn.close()
+        await pool.release(conn)

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI, APIRouter, Depends
 dotenv.load_dotenv()
 
 from databutton_app.mw.auth_mw import AuthConfig, get_authorized_user
+from app.libs.database import init_db_pool, close_db_pool
 
 
 def get_router_config() -> dict:
@@ -103,3 +104,13 @@ def create_app() -> FastAPI:
 
 
 app = create_app()
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    await init_db_pool()
+
+
+@app.on_event("shutdown")
+async def on_shutdown() -> None:
+    await close_db_pool()


### PR DESCRIPTION
## Summary
- manage DB connections with a global asyncpg connection pool
- initialize and close the pool on startup/shutdown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cc0712a048326a92a4bf0089991a3