### PR TITLE
Add backend env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,10 @@ backend\install.bat
 frontend\install.bat
 ```
 
-3. Create a `.env` file inside `backend/` and set your database connection and
-other environment variables:
+3. Copy the provided `.env.example` to `.env` and adjust the values as needed:
 
 ```bash
-echo DATABASE_URL=postgresql://user:password@localhost/solarsync > backend/.env
+cp backend/.env.example backend/.env
 ```
 
 4. Run the SQL migrations in order:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+# Example environment configuration for the FastAPI backend
+
+# Database connection string
+DATABASE_URL=postgresql://user:password@localhost/solarsync
+
+# Optional variables used when running on Databutton
+# DATABUTTON_SERVICE_TYPE=prodx
+# DATABUTTON_EXTENSIONS=[]

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,9 +21,14 @@ install.bat
 
 ## Environment variables
 
-Create a `.env` file in this folder with your database connection string and any
-other variables required by the application. The most important one is
-`DATABASE_URL`:
+Copy `.env.example` to `.env` in this folder and edit the values. The main
+variable required is `DATABASE_URL`:
+
+```bash
+cp .env.example .env
+```
+
+For example:
 
 ```bash
 DATABASE_URL=postgresql://user:password@localhost/solarsync


### PR DESCRIPTION
## Summary
- add `backend/.env.example` showing database url and optional vars
- reference env example in backend instructions
- document copying env example in main README

## Testing
- `make -n`

------
https://chatgpt.com/codex/tasks/task_e_685cc07215a483268020e7ef40a9526c