### PR TITLE
Expose Brain class and stack app hooks

### DIFF
--- a/frontend/src/app/index.ts
+++ b/frontend/src/app/index.ts
@@ -24,6 +24,7 @@ export {
   mode,
 } from "../constants";
 export * from "./auth";
+export { useStackApp } from "@stackframe/react";
 
 import brain from "../brain";
 export const backend = brain;

--- a/frontend/src/brain/index.ts
+++ b/frontend/src/brain/index.ts
@@ -58,3 +58,4 @@ const constructClient = () => {
 const brain = constructClient();
 
 export default brain;
+export { Brain } from "./Brain";


### PR DESCRIPTION
## Summary
- re-export `Brain` from the brain package
- expose `useStackApp` for pages

## Testing
- `yarn lint` *(fails: Error when performing the request to https://repo.yarnpkg.com)*
- `yarn build` *(fails: Error when performing the request to https://repo.yarnpkg.com)*

------
https://chatgpt.com/codex/tasks/task_e_685d918713bc8326a053e94319c895e1