### PR TITLE
Add httpx dependency

### DIFF
--- a/backend/install.bat
+++ b/backend/install.bat
@@ -32,6 +32,7 @@ pip install python-dotenv==1.0.0
 pip install requests==2.31.0
 pip install beautifulsoup4==4.12.2
 pip install PyJWT==2.8.0
+pip install httpx==0.24.1
 
 echo Installation completed!
 echo Testing FastAPI installation...

--- a/backend/install.sh
+++ b/backend/install.sh
@@ -3,3 +3,4 @@
 uv venv .venv
 source .venv/bin/activate
 uv pip install -r requirements.txt
+uv pip install httpx==0.24.1

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,4 +8,5 @@ dependencies = [
     # Versions are kept in sync with requirements.txt
     "fastapi==0.104.1",
     "uvicorn[standard]==0.24.0",
+    "httpx==0.24.1",
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ requests==2.31.0
 beautifulsoup4==4.12.2
 PyJWT==2.8.0
 aiosmtplib==2.0.2
+httpx==0.24.1


### PR DESCRIPTION
## Summary
- add httpx with FastAPI compatible version to requirements and project metadata
- install httpx in backend installers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685d98bcbcb883268d037f8cfea94446