### PR TITLE
Fix undefined auth config

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,10 +30,10 @@ export default defineConfig({
       '@stackframe/react': path.resolve(__dirname, './src/lib/stackframe.tsx'),
     },
   },
-  define: {
-    __APP_ID__: JSON.stringify('dev-app-id'),
-    __API_PATH__: JSON.stringify('/api'),
-    __API_URL__: JSON.stringify('http://localhost:8000/api'),
+    define: {
+      __APP_ID__: JSON.stringify('dev-app-id'),
+      __API_PATH__: JSON.stringify('/api'),
+      __API_URL__: JSON.stringify('http://localhost:8000/api'),
     __API_HOST__: JSON.stringify('localhost:8000'),
     __API_PREFIX_PATH__: JSON.stringify('/api'),
     __WS_API_URL__: JSON.stringify('ws://localhost:8000'),
@@ -42,9 +42,11 @@ export default defineConfig({
     __APP_FAVICON_LIGHT__: JSON.stringify('/light.ico'),
     __APP_FAVICON_DARK__: JSON.stringify('/dark.ico'),
     __APP_DEPLOY_USERNAME__: JSON.stringify(''),
-    __APP_DEPLOY_APPNAME__: JSON.stringify(''),
-    __APP_DEPLOY_CUSTOM_DOMAIN__: JSON.stringify(''),
-  },
+      __APP_DEPLOY_APPNAME__: JSON.stringify(''),
+      __APP_DEPLOY_CUSTOM_DOMAIN__: JSON.stringify(''),
+      // Provide a default empty config for optional auth extension
+      __STACK_AUTH_CONFIG__: JSON.stringify('{}'),
+    },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary
- provide a default `__STACK_AUTH_CONFIG__` in Vite config

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685dc4d2f51c8326a065f05d7bc74fe9