### PR TITLE
Fix Vite alias for UI components

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,20 +12,20 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
       brain: path.resolve(__dirname, './src/brain'),
       types: path.resolve(__dirname, './src/brain/data-contracts.ts'),
-      'components': path.resolve(__dirname, './src/components'),
-      'pages': path.resolve(__dirname, './src/pages'),
+      components: path.resolve(__dirname, './src/components'),
+      pages: path.resolve(__dirname, './src/pages'),
       app: path.resolve(__dirname, './src/app'),
       'app/auth': path.resolve(__dirname, './src/app/auth'),
-      'utils': path.resolve(__dirname, './src/utils'),
-      '@/lib': path.resolve(__dirname, './src/lib'),
-      '@/hooks': path.resolve(__dirname, './src/extensions/shadcn/hooks'),
-      '@/components/hooks': path.resolve(
+      utils: path.resolve(__dirname, './src/utils'),
+      '@/lib/': path.resolve(__dirname, './src/lib/'),
+      '@/hooks/': path.resolve(__dirname, './src/extensions/shadcn/hooks/'),
+      '@/components/hooks/': path.resolve(
         __dirname,
-        './src/extensions/shadcn/hooks'
+        './src/extensions/shadcn/hooks/'
       ),
-      '@/components/ui': path.resolve(
+      '@/components/ui/': path.resolve(
         __dirname,
-        './src/extensions/shadcn/components'
+        './src/extensions/shadcn/components/'
       ),
       '@stackframe/react': path.resolve(__dirname, './src/lib/stackframe.tsx'),
     },


### PR DESCRIPTION
## Summary
- update Vite alias mapping to handle UI component paths

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685dc83439d48326b139e87ac9657e8b