### PR TITLE
Fix vite alias resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,5 @@ logs/
 # OS
 .DS_Store
 Thumbs.db
-"@ | Out-File -FilePath ".gitignore" -Encoding UTF8
+"@ | Out-File -FilePath ".gitignore" -Encoding UTF8# Criar yarn.lock vazio no frontend
+New-Item -Path "yarn.lock" -ItemType File

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,27 +8,54 @@ import path from 'path'
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      brain: path.resolve(__dirname, './src/brain'),
-      types: path.resolve(__dirname, './src/brain/data-contracts.ts'),
-      components: path.resolve(__dirname, './src/components'),
-      pages: path.resolve(__dirname, './src/pages'),
-      app: path.resolve(__dirname, './src/app'),
-      'app/auth': path.resolve(__dirname, './src/app/auth'),
-      utils: path.resolve(__dirname, './src/utils'),
-      '@/lib/': path.resolve(__dirname, './src/lib/'),
-      '@/hooks/': path.resolve(__dirname, './src/extensions/shadcn/hooks/'),
-      '@/components/hooks/': path.resolve(
-        __dirname,
-        './src/extensions/shadcn/hooks/'
-      ),
-      '@/components/ui/': path.resolve(
-        __dirname,
-        './src/extensions/shadcn/components/'
-      ),
-      '@stackframe/react': path.resolve(__dirname, './src/lib/stackframe.tsx'),
-    },
+    alias: [
+      {
+        find: '@/components/ui',
+        replacement: path.resolve(
+          __dirname,
+          './src/extensions/shadcn/components'
+        ),
+      },
+      {
+        find: '@/components/hooks',
+        replacement: path.resolve(
+          __dirname,
+          './src/extensions/shadcn/hooks'
+        ),
+      },
+      {
+        find: '@/hooks',
+        replacement: path.resolve(
+          __dirname,
+          './src/extensions/shadcn/hooks'
+        ),
+      },
+      {
+        find: '@/lib',
+        replacement: path.resolve(__dirname, './src/lib'),
+      },
+      { find: 'brain', replacement: path.resolve(__dirname, './src/brain') },
+      {
+        find: 'types',
+        replacement: path.resolve(
+          __dirname,
+          './src/brain/data-contracts.ts'
+        ),
+      },
+      {
+        find: 'components',
+        replacement: path.resolve(__dirname, './src/components'),
+      },
+      { find: 'pages', replacement: path.resolve(__dirname, './src/pages') },
+      { find: 'app/auth', replacement: path.resolve(__dirname, './src/app/auth') },
+      { find: 'app', replacement: path.resolve(__dirname, './src/app') },
+      { find: 'utils', replacement: path.resolve(__dirname, './src/utils') },
+      {
+        find: '@stackframe/react',
+        replacement: path.resolve(__dirname, './src/lib/stackframe.tsx'),
+      },
+      { find: '@', replacement: path.resolve(__dirname, './src') },
+    ],
   },
     define: {
       __APP_ID__: JSON.stringify('dev-app-id'),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,24 +2,19 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-
-
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@/components/ui/': path.resolve(
-        __dirname,
-        './src/extensions/shadcn/components/'
-      ),
-      '@/components/hooks/': path.resolve(
-        __dirname,
-        './src/extensions/shadcn/hooks/'
-      ),
-      '@/hooks/': path.resolve(__dirname, './src/extensions/shadcn/hooks/'),
+      // Prioritize shadcn aliases
       '@/lib/': path.resolve(__dirname, './src/lib/'),
+      '@/hooks/': path.resolve(__dirname, './src/extensions/shadcn/hooks/'),
+      '@/components/hooks/': path.resolve(__dirname, './src/extensions/shadcn/hooks/'),
+      '@/components/ui/': path.resolve(__dirname, './src/extensions/shadcn/components/'),
       '@stackframe/react': path.resolve(__dirname, './src/lib/stackframe.tsx'),
+      
+      // General aliases
       '@': path.resolve(__dirname, './src'),
       brain: path.resolve(__dirname, './src/brain'),
       types: path.resolve(__dirname, './src/brain/data-contracts.ts'),
@@ -30,10 +25,10 @@ export default defineConfig({
       utils: path.resolve(__dirname, './src/utils'),
     },
   },
-    define: {
-      __APP_ID__: JSON.stringify('dev-app-id'),
-      __API_PATH__: JSON.stringify('/api'),
-      __API_URL__: JSON.stringify('http://localhost:8000/api'),
+  define: {
+    __APP_ID__: JSON.stringify('dev-app-id'),
+    __API_PATH__: JSON.stringify('/api'),
+    __API_URL__: JSON.stringify('http://localhost:8000/api'),
     __API_HOST__: JSON.stringify('localhost:8000'),
     __API_PREFIX_PATH__: JSON.stringify('/api'),
     __WS_API_URL__: JSON.stringify('ws://localhost:8000'),
@@ -42,11 +37,11 @@ export default defineConfig({
     __APP_FAVICON_LIGHT__: JSON.stringify('/light.ico'),
     __APP_FAVICON_DARK__: JSON.stringify('/dark.ico'),
     __APP_DEPLOY_USERNAME__: JSON.stringify(''),
-      __APP_DEPLOY_APPNAME__: JSON.stringify(''),
-      __APP_DEPLOY_CUSTOM_DOMAIN__: JSON.stringify(''),
-      // Provide a default empty config for optional auth extension
-      __STACK_AUTH_CONFIG__: JSON.stringify('{}'),
-    },
+    __APP_DEPLOY_APPNAME__: JSON.stringify(''),
+    __APP_DEPLOY_CUSTOM_DOMAIN__: JSON.stringify(''),
+    // Provide a default empty config for optional auth extension
+    __STACK_AUTH_CONFIG__: JSON.stringify('{}'),
+  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary
- prioritize shadcn component aliases in Vite config

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685dcac41dd48326b1ca396c20cade7d