### PR TITLE
Switch tests to httpx AsyncClient

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 import uuid
-from fastapi.testclient import TestClient
+import httpx
 from backend.main import create_app
 from app.libs import database
 from databutton_app.mw import auth_mw
@@ -80,6 +80,6 @@ def app(fake_db, monkeypatch):
 
 
 @pytest.fixture
-def client(app):
-    with TestClient(app) as tc:
-        yield tc
+async def client(app):
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac


### PR DESCRIPTION
## Summary
- update the testing client to use `httpx.AsyncClient`
- provide an async fixture for the FastAPI app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685ddab8af008326a75cb54567ed7d5a