### PR TITLE
Fix backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,4 @@ beautifulsoup4==4.12.2
 
 # Email
 aiosmtplib==2.0.2
+httpx==0.24.1


### PR DESCRIPTION
## Summary
- align requirements with `pyproject.toml` by adding `httpx==0.24.1`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ddab7dba48326a2366853946b6d4b