### PR TITLE
docs: explain how to install packages for backend tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -67,6 +67,15 @@ run_backend.bat         # Windows
 
 ## Running tests
 
+Before executing the tests, make sure the required Python packages are
+installed:
+
+```bash
+pip install -r requirements.txt
+```
+
+The suite relies on the `httpx` package for the async test client.
+
 After installing dependencies, run the automated test suite with `pytest`:
 
 ```bash


### PR DESCRIPTION
## Summary
- update backend instructions on running tests

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685e136e07a083269fb6d2a92820d53e